### PR TITLE
Update security patch string to 2016-06-01

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1915,7 +1915,16 @@ $(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(DISTTOOLS)
 
 SLIM_TARGET_PACKAGE := $(PRODUCT_OUT)/$(SLIM_MOD_VERSION).zip
 
-.PHONY: otapackage bacon bootzip
+BOOT_ZIP_FROM_IMAGE_SCRIPT := ./build/tools/releasetools/boot_flash_from_image
+KERNEL_PATH := $(TARGET_KERNEL_SOURCE)/arch/arm/configs/$(TARGET_KERNEL_CONFIG)
+ 
+.PHONY: bootzip otapackage bacon
+ bootzip: bootimage
+	$(BOOT_ZIP_FROM_IMAGE_SCRIPT) \
+ 	   $(recovery_fstab) \
+ 	   $(OUT) \
+ 	   $(TARGET_DEVICE)
+	   
 otapackage: $(INTERNAL_OTA_PACKAGE_TARGET)
 bacon: otapackage
 	$(hide) ln -f $(INTERNAL_OTA_PACKAGE_TARGET) $(SLIM_TARGET_PACKAGE)

--- a/core/Makefile
+++ b/core/Makefile
@@ -1915,16 +1915,7 @@ $(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(DISTTOOLS)
 
 SLIM_TARGET_PACKAGE := $(PRODUCT_OUT)/$(SLIM_MOD_VERSION).zip
 
-BOOT_ZIP_FROM_IMAGE_SCRIPT := ./build/tools/releasetools/boot_flash_from_image
-KERNEL_PATH := $(TARGET_KERNEL_SOURCE)/arch/arm/configs/$(TARGET_KERNEL_CONFIG)
- 
-.PHONY: bootzip otapackage bacon
- bootzip: bootimage
-	$(BOOT_ZIP_FROM_IMAGE_SCRIPT) \
- 	   $(recovery_fstab) \
- 	   $(OUT) \
- 	   $(TARGET_DEVICE)
-	   
+.PHONY: otapackage bacon bootzip
 otapackage: $(INTERNAL_OTA_PACKAGE_TARGET)
 bacon: otapackage
 	$(hide) ln -f $(INTERNAL_OTA_PACKAGE_TARGET) $(SLIM_TARGET_PACKAGE)

--- a/core/binary.mk
+++ b/core/binary.mk
@@ -30,6 +30,15 @@ else
   endif
 endif
 
+# Many qcom modules don't correctly set a dependency on the kernel headers. Fix it for them,
+ # but warn the user.
+ ifneq (,$(findstring $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include,$(LOCAL_C_INCLUDES)))
+   ifeq (,$(findstring $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr,$(LOCAL_ADDITIONAL_DEPENDENCIES)))
+     $(warning $(LOCAL_MODULE) uses kernel headers, but does not depend on them!)
+     LOCAL_ADDITIONAL_DEPENDENCIES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
+   endif
+ endif
+
 # The following LOCAL_ variables will be modified in this file.
 # Because the same LOCAL_ variables may be used to define modules for both 1st arch and 2nd arch,
 # we can't modify them in place.

--- a/core/build_id.mk
+++ b/core/build_id.mk
@@ -18,4 +18,4 @@
 # (like "CRB01").  It must be a single word, and is
 # capitalized by convention.
 
-export BUILD_ID=MOB30J
+export BUILD_ID=MOB30M

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -103,7 +103,7 @@ ifeq "" "$(PLATFORM_SECURITY_PATCH)"
   # Can be an arbitrary string, but must be a single word.
   #
   # If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-  PLATFORM_SECURITY_PATCH := 2016-05-01
+  PLATFORM_SECURITY_PATCH := 2016-06-01
 endif
 
 ifeq "" "$(PLATFORM_BASE_OS)"


### PR DESCRIPTION
b/28269112

Change-Id: Icf65bbf784951d1f9b56ce88f59b50661af1a32c
- "MOB30K"
- "MOB30L"
- MOB30M
- build: add kernel header dependency if module uses kernel headers

Many of the QCOM components use kernel headers, but don't declare
the dependency on them.  This is fine in CAF because of the way they
build the boot.img before anything else.  In CM, we don't build the
boot.img the same, so we run into a race between the kernel build &
these modules... and the modules lose.

Warn about modules that have this missing dependency, and add it for
them so we don't have to modify each Android.mk.

Change-Id: I95f1e47b5ef440f6f5d8f64a0c3f38d9572e839e
